### PR TITLE
Variadic parameters

### DIFF
--- a/php-initialized.inc.php
+++ b/php-initialized.inc.php
@@ -207,16 +207,14 @@ function check_variables($filename, $initialized = array(), $function = "", $cla
 		// constants
 		} elseif (!$in_string && $token[0] === T_STRING && !in_array($tokens[$i-1][0], array(T_OBJECT_OPERATOR, T_NEW, T_INSTANCEOF), true) && $tokens[$i+1][0] !== T_DOUBLE_COLON) { // not properties and classes
 			$name = $token[1];
-			if ($name == strtolower($name)) {
-				if ($tokens[$i-1][0] === T_CONST) {
-					$globals[($class ? "$class::" : "") . $name] = true;
-				} else {
-					if ($tokens[$i-1][0] === T_DOUBLE_COLON) {
-						$name = (!strcasecmp($tokens[$i-2][1], "self") ? $class : $tokens[$i-2][1]) . "::$name"; //! extends
-					}
-					if (!defined($name) && !isset($globals[$name])) { //! case-insensitive constants
-						echo "Uninitialized constant $name in $filename on line $token[2]\n";
-					}
+			if ($tokens[$i-1][0] === T_CONST) {
+				$globals[($class ? "$class::" : "") . $name] = true;
+			} else {
+				if ($tokens[$i-1][0] === T_DOUBLE_COLON) {
+					$name = (!strcasecmp($tokens[$i-2][1], "self") ? $class : $tokens[$i-2][1]) . "::$name"; //! extends
+				}
+				if (!defined($name) && !isset($globals[$name])) { //! case-insensitive constants
+					echo "Uninitialized constant $name in $filename on line $token[2]\n";
 				}
 			}
 		

--- a/php-initialized.inc.php
+++ b/php-initialized.inc.php
@@ -37,7 +37,7 @@ function check_variables($filename, $initialized = array(), $function = "", $cla
 	$shortcircuit = array();
 	for (; $i < count($tokens); $i++) {
 		$token = $tokens[$i];
-		//~ echo (is_array($token) ? token_name($token[0]) . "\t" . trim($token[1]) : "\t$token") . "\n";
+		//~ echo "Token $i: " . (is_array($token) ? token_name($token[0]) . "\t" . trim($token[1]) : "\t$token") . "\n";
 		//~ continue;
 		
 		if ($token === ')' || $token === ';' || $token === ',') {
@@ -174,7 +174,11 @@ function check_variables($filename, $initialized = array(), $function = "", $cla
 				$reflection = ($class_name ? new ReflectionMethod($class_name, $name) : new ReflectionFunction($name));
 				$parameters = array();
 				foreach ($reflection->getParameters() as $parameter) {
-					$parameters[] = ($parameter->isPassedByReference() ? '$' . $parameter->getName() : '');
+					$parameters[] = ($parameter->isPassedByReference() 
+					                    ? ($parameter->isVariadic()
+					                        ? '$...'
+					                        : '$' . $parameter->getName())
+					                    : '');
 				}
 				$function_calls[] = $parameters;
 			} else {

--- a/tests/run-tests.php
+++ b/tests/run-tests.php
@@ -19,7 +19,9 @@ if (isset($_GET["coverage"])) {
 }
 
 foreach (glob("*.phpt") as $filename) {
-	preg_match("~^--TEST--\n(.*)\n--FILE--\n(.*)\n--EXPECTF--\n(.*)~s", file_get_contents($filename), $match);
+	preg_match("~^--TEST--\n(.*)\n--FILE--\n(.*)\n--EXPECTF--\n(.*)~s", 
+	           str_replace("\r\n", "\n", file_get_contents($filename)),     // DOS -> Unix
+	           $match);
 	ob_start();
 	check_variables($filename);
 	if (!preg_match('(^' . str_replace("%s", ".*", preg_quote($match[3])) . '$)', ob_get_clean())) {


### PR DESCRIPTION
I noticed that test `24-sscanf.php` was failing, and found that `php-initialized` wasn't marking the variadic parameter as such.

Other minor fixes were to have the test runner accept DOS format files (\r\n line endings), and I reversed out a change that seemed to limit constant checking to lower-case.  I prefer `php-initialized` to check everything.